### PR TITLE
fix: improve Calendar permission error handling and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ MCP server for [Fantastical](https://flexibits.com/fantastical) - the powerful c
 - macOS (Fantastical is macOS-only)
 - Node.js 18+
 - [Fantastical](https://flexibits.com/fantastical) installed
-- Calendar access permissions for Terminal/Claude
+- **For reading events**: macOS Calendar app Automation permissions (see [Permissions](#permissions))
 
 ## Installation
 
@@ -87,9 +87,18 @@ Add to `~/.claude.json`:
 
 ### Permissions
 
-On first run, you may need to grant accessibility permissions:
-1. System Preferences → Privacy & Security → Accessibility
-2. Add Terminal (or your terminal app) to the allowed list
+**Event creation** (`fantastical_create_event`) and **navigation** (`fantastical_show_date`, `fantastical_search`) use Fantastical's URL scheme and don't require special permissions.
+
+**Reading events** (`fantastical_get_today`, `fantastical_get_upcoming`, `fantastical_get_calendars`) uses the macOS Calendar app (which Fantastical syncs with) and requires Automation permissions:
+
+1. Open **System Settings → Privacy & Security → Automation**
+2. Find the app running the MCP server (Terminal, iTerm, VS Code, etc.)
+3. Enable the **Calendar** toggle
+
+**Note for MCP subprocess environments** (like Claude Code):
+- macOS Automation permissions may not inherit properly to subprocesses
+- You may need to grant permission to the Node.js process itself
+- If permissions can't be granted, the tools will show a helpful error and offer to open Fantastical as a fallback
 
 ## Usage Examples
 
@@ -141,7 +150,22 @@ node dist/index.js
 
 ## Troubleshooting
 
-### "AppleScript error: Not authorized to send Apple events"
+### "AppleScript error: Not authorised to send Apple events to Calendar" (-1743)
+
+This error occurs when reading events (get_today, get_upcoming, get_calendars). The tools read from the macOS Calendar app.
+
+**Fix:**
+1. Open **System Settings → Privacy & Security → Automation**
+2. Find the app running the MCP server (Terminal, iTerm, VS Code, Cursor, etc.)
+3. Enable the **Calendar** toggle
+
+**If running in Claude Code or similar MCP environments:**
+- The subprocess may not inherit permissions from the parent terminal
+- Try running `osascript -e 'tell application "Calendar" to get calendars'` directly in terminal to trigger the permission prompt
+- If that works but MCP still fails, try restarting the MCP server
+- As a last resort, use `fantastical_show_date` to navigate Fantastical manually
+
+### "AppleScript error: Not authorized to send Apple events" (general)
 Grant accessibility permissions:
 1. Open System Preferences → Privacy & Security → Accessibility
 2. Click the lock to make changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-fantastical",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-fantastical",
-      "version": "1.0.0",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
@@ -369,7 +369,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -1095,7 +1094,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,13 @@ async function runAppleScriptMultiline(script: string): Promise<string> {
   }
 }
 
+// Helper to open Fantastical via URL scheme
+// Note: Do NOT use AppleScript `parse sentence` for navigation - it types into the event
+// creation dialog instead of navigating. URL schemes are the correct approach.
+async function openFantasticalUrl(url: string): Promise<void> {
+  await execAsync(`open "${url}"`);
+}
+
 // Check if Fantastical is installed
 async function checkFantasticalInstalled(): Promise<boolean> {
   try {
@@ -235,9 +242,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
 
         const url = `x-fantastical3://parse?${params.toString()}`;
-        const script = `do shell script "open '${url}'"`;
-
-        await runAppleScript(script);
+        await openFantasticalUrl(url);
 
         return {
           content: [{
@@ -303,8 +308,8 @@ return output`;
           };
         } catch (error) {
           if (isCalendarPermissionError(error)) {
-            // Offer to open Fantastical as a fallback
-            await runAppleScript('do shell script "open \'x-fantastical3://show/calendar/today\'"');
+            // Offer to open Fantastical as a fallback (use URL scheme, not parse sentence)
+            await openFantasticalUrl('x-fantastical3://show/calendar/today');
             return {
               content: [{
                 type: "text",
@@ -375,8 +380,8 @@ return output`;
           };
         } catch (error) {
           if (isCalendarPermissionError(error)) {
-            // Offer to open Fantastical as a fallback
-            await runAppleScript('do shell script "open \'x-fantastical3://show/calendar/today\'"');
+            // Offer to open Fantastical as a fallback (use URL scheme, not parse sentence)
+            await openFantasticalUrl('x-fantastical3://show/calendar/today');
             return {
               content: [{
                 type: "text",
@@ -392,9 +397,8 @@ return output`;
       case "fantastical_show_date": {
         const { date } = args as { date: string };
 
-        // Use URL scheme to show date in Fantastical
-        const script = `do shell script "open 'x-fantastical3://show/calendar/${encodeURIComponent(date)}'"`;
-        await runAppleScript(script);
+        // Use URL scheme to show date in Fantastical (not parse sentence which types into event dialog)
+        await openFantasticalUrl(`x-fantastical3://show/calendar/${encodeURIComponent(date)}`);
 
         return {
           content: [{
@@ -452,9 +456,8 @@ return output`;
       case "fantastical_search": {
         const { query } = args as { query: string };
 
-        // Search using URL scheme which opens Fantastical's search
-        const script = `do shell script "open 'x-fantastical3://search?query=${encodeURIComponent(query)}'"`;
-        await runAppleScript(script);
+        // Search using URL scheme which opens Fantastical's search (not parse sentence)
+        await openFantasticalUrl(`x-fantastical3://search?query=${encodeURIComponent(query)}`);
 
         return {
           content: [{

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,12 @@
  * Requirements:
  * - macOS only
  * - Fantastical installed
- * - Accessibility permissions for osascript
+ * - For reading events: macOS Calendar app automation permissions
+ *   (System Settings → Privacy & Security → Automation → [your terminal/app] → Calendar)
+ *
+ * Note: Event creation uses Fantastical's URL scheme and doesn't require Calendar permissions.
+ * Reading events (get_today, get_upcoming, get_calendars) uses the macOS Calendar app
+ * since Fantastical's AppleScript interface doesn't support querying events.
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -22,6 +27,33 @@ import { exec } from "child_process";
 import { promisify } from "util";
 
 const execAsync = promisify(exec);
+
+// Error codes
+const CALENDAR_PERMISSION_ERROR = -1743;
+
+// Helper to check if error is a Calendar permission error
+function isCalendarPermissionError(error: unknown): boolean {
+  if (error instanceof Error) {
+    return error.message.includes('-1743') ||
+           error.message.includes('Not authorised to send Apple events to Calendar');
+  }
+  return false;
+}
+
+// User-friendly error message for Calendar permission issues
+const CALENDAR_PERMISSION_MESSAGE = `Calendar app permission denied.
+
+This tool reads events from the macOS Calendar app (which Fantastical syncs with).
+To fix this, grant Calendar automation permission:
+
+1. Open System Settings → Privacy & Security → Automation
+2. Find the app running this MCP server (e.g., Terminal, iTerm, VS Code, or Node)
+3. Enable the "Calendar" toggle
+
+Note: If running in a subprocess (like Claude Code), you may need to grant permission
+to the parent application or the Node.js process itself.
+
+As a workaround, I can open Fantastical to show your calendar instead.`;
 
 // Helper to run AppleScript
 async function runAppleScript(script: string): Promise<string> {
@@ -97,7 +129,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: "fantastical_get_today",
-    description: "Get today's calendar events from Fantastical",
+    description: "Get today's calendar events. Note: Reads from macOS Calendar app (synced with Fantastical). Requires Calendar automation permission.",
     inputSchema: {
       type: "object" as const,
       properties: {},
@@ -106,7 +138,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: "fantastical_get_upcoming",
-    description: "Get upcoming calendar events from Fantastical",
+    description: "Get upcoming calendar events. Note: Reads from macOS Calendar app (synced with Fantastical). Requires Calendar automation permission.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -134,7 +166,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: "fantastical_get_calendars",
-    description: "List all available calendars in Fantastical",
+    description: "List all available calendars. Note: Reads from macOS Calendar app (synced with Fantastical). Requires Calendar automation permission.",
     inputSchema: {
       type: "object" as const,
       properties: {},
@@ -248,26 +280,41 @@ tell application "Calendar"
 end tell
 return output`;
 
-        const result = await runAppleScriptMultiline(script);
-        const events = result
-          .split("\n")
-          .filter(line => line.trim())
-          .map(line => {
-            const [calendar, title, start, end, location] = line.split("|");
-            return { calendar, title, start, end, location: location || "" };
-          })
-          .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+        try {
+          const result = await runAppleScriptMultiline(script);
+          const events = result
+            .split("\n")
+            .filter(line => line.trim())
+            .map(line => {
+              const [calendar, title, start, end, location] = line.split("|");
+              return { calendar, title, start, end, location: location || "" };
+            })
+            .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
 
-        return {
-          content: [{
-            type: "text",
-            text: JSON.stringify({
-              date: new Date().toISOString().split("T")[0],
-              count: events.length,
-              events,
-            }, null, 2),
-          }],
-        };
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({
+                date: new Date().toISOString().split("T")[0],
+                count: events.length,
+                events,
+              }, null, 2),
+            }],
+          };
+        } catch (error) {
+          if (isCalendarPermissionError(error)) {
+            // Offer to open Fantastical as a fallback
+            await runAppleScript('do shell script "open \'x-fantastical3://show/calendar/today\'"');
+            return {
+              content: [{
+                type: "text",
+                text: CALENDAR_PERMISSION_MESSAGE + "\n\nFallback: Opened Fantastical to today's view.",
+              }],
+              isError: true,
+            };
+          }
+          throw error;
+        }
       }
 
       case "fantastical_get_upcoming": {
@@ -301,30 +348,45 @@ tell application "Calendar"
 end tell
 return output`;
 
-        const result = await runAppleScriptMultiline(script);
-        const events = result
-          .split("\n")
-          .filter(line => line.trim())
-          .map(line => {
-            const [calendar, title, start, end, location] = line.split("|");
-            return { calendar, title, start, end, location: location || "" };
-          })
-          .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+        try {
+          const result = await runAppleScriptMultiline(script);
+          const events = result
+            .split("\n")
+            .filter(line => line.trim())
+            .map(line => {
+              const [calendar, title, start, end, location] = line.split("|");
+              return { calendar, title, start, end, location: location || "" };
+            })
+            .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
 
-        return {
-          content: [{
-            type: "text",
-            text: JSON.stringify({
-              range: {
-                start: today.toISOString().split("T")[0],
-                end: endDate.toISOString().split("T")[0],
-                days,
-              },
-              count: events.length,
-              events,
-            }, null, 2),
-          }],
-        };
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({
+                range: {
+                  start: today.toISOString().split("T")[0],
+                  end: endDate.toISOString().split("T")[0],
+                  days,
+                },
+                count: events.length,
+                events,
+              }, null, 2),
+            }],
+          };
+        } catch (error) {
+          if (isCalendarPermissionError(error)) {
+            // Offer to open Fantastical as a fallback
+            await runAppleScript('do shell script "open \'x-fantastical3://show/calendar/today\'"');
+            return {
+              content: [{
+                type: "text",
+                text: CALENDAR_PERMISSION_MESSAGE + "\n\nFallback: Opened Fantastical to today's view.",
+              }],
+              isError: true,
+            };
+          }
+          throw error;
+        }
       }
 
       case "fantastical_show_date": {
@@ -357,21 +419,34 @@ tell application "Calendar"
 end tell
 return output`;
 
-        const result = await runAppleScriptMultiline(script);
-        const calendars = result
-          .split("\n")
-          .filter(line => line.trim())
-          .map(name => ({ name }));
+        try {
+          const result = await runAppleScriptMultiline(script);
+          const calendars = result
+            .split("\n")
+            .filter(line => line.trim())
+            .map(name => ({ name }));
 
-        return {
-          content: [{
-            type: "text",
-            text: JSON.stringify({
-              count: calendars.length,
-              calendars,
-            }, null, 2),
-          }],
-        };
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({
+                count: calendars.length,
+                calendars,
+              }, null, 2),
+            }],
+          };
+        } catch (error) {
+          if (isCalendarPermissionError(error)) {
+            return {
+              content: [{
+                type: "text",
+                text: CALENDAR_PERMISSION_MESSAGE,
+              }],
+              isError: true,
+            };
+          }
+          throw error;
+        }
       }
 
       case "fantastical_search": {


### PR DESCRIPTION
## Summary

- Detect macOS Automation Calendar permission errors (AppleScript -1743) and return a clearer, actionable message
- Add a small fallback: open Fantastical directly when Calendar automation is blocked
- Document the permission requirement + troubleshooting

## Code references

- Permission error detection: src/index.ts:35 (isCalendarPermissionError() checks for -1743)
- Fallback URL opener: src/index.ts:95 (openFantasticalUrl() helper)
- Fallback trigger sites (catch blocks):
  - src/index.ts:309-312
  - src/index.ts:381-384
  - src/index.ts:442-443

## Notes / claims

I do not have hard data on how often various MCP subprocess environments hit -1743, so this PR treats it as a pragmatic improvement: when it happens, the error is explained and the user gets a workable fallback.

## Version

This PR includes a version bump 1.0.0 -> 1.0.3.

## Testing

- Verified behavior locally by running without Calendar Automation permissions: error is detected and a helpful message is returned
- Verified Fantastical fallback launches when the permission error is hit

Fixes #2