### PR TITLE
feat: add native EventKit helper for reliable calendar access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-02-21
+
+### Added
+- Native EventKit helper (`native/FantasticalHelper.swift`) for fast, reliable calendar access
+- Fallback mechanism: tries EventKit helper first, falls back to AppleScript if unavailable
+- Build script for native helper (`npm run build:native`)
+
+### Fixed
+- Calendar permission errors (-1743) when running in MCP subprocess contexts
+- Timeouts on large calendars (3000+ events) due to slow AppleScript `whose` filters
+- Permission inheritance issues in process chains (terminal → node → osascript)
+
+### Changed
+- `fantastical_get_today`, `fantastical_get_upcoming`, `fantastical_get_calendars` now use EventKit by default
+- Updated README with Full Calendar Access permission requirements
+- Added troubleshooting section for Calendar permission issues
+
 ## [1.0.3] - 2025-11-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ npm run build
 
 ## Configuration
 
-No API keys required - this server uses AppleScript to communicate with Fantastical and the Calendar app.
+This server uses a hybrid approach for optimal performance and compatibility:
+- **EventKit (preferred)**: Native Swift helper for fast, reliable calendar access
+- **AppleScript (fallback)**: Used if the native helper is unavailable
+
+No API keys required.
 
 ### For Claude Desktop
 
@@ -87,9 +91,17 @@ Add to `~/.claude.json`:
 
 ### Permissions
 
-On first run, you may need to grant accessibility permissions:
+On first run, you may need to grant the following permissions:
+
+**Accessibility (for event creation via URL scheme):**
 1. System Preferences → Privacy & Security → Accessibility
 2. Add Terminal (or your terminal app) to the allowed list
+
+**Full Calendar Access (for reading events):**
+1. System Preferences → Privacy & Security → Calendars
+2. Grant "Full Calendar Access" to your terminal app or the process running the MCP server
+
+Note: On macOS Sonoma and later, reading calendar events via AppleScript may fail with permission errors when running in subprocess contexts (e.g., MCP servers spawned by Claude). The native EventKit helper resolves this by using a different permission model.
 
 ## Usage Examples
 
@@ -147,6 +159,14 @@ Grant accessibility permissions:
 2. Click the lock to make changes
 3. Add Terminal (or your terminal app) and enable it
 
+### Calendar permission errors (-1743) or timeouts when reading events
+This occurs when the MCP server runs in a subprocess context (e.g., spawned by Claude Code or other MCP clients). macOS TCC permissions don't properly inherit through process chains.
+
+**Solutions:**
+1. **Recommended**: The native EventKit helper (`dist/native/fantastical-helper`) handles this automatically. Rebuild with `npm run build` to compile it.
+2. Grant "Full Calendar Access" in System Settings → Privacy & Security → Calendars to the terminal app
+3. If running from source, ensure the Swift helper is compiled: `npm run build:native`
+
 ### "Error: This MCP server only works on macOS"
 This server requires macOS because Fantastical is a macOS application. It uses AppleScript to communicate with Fantastical and the Calendar app.
 
@@ -154,6 +174,7 @@ This server requires macOS because Fantastical is a macOS application. It uses A
 - Ensure Fantastical is syncing with iCloud/Calendar
 - Check that Calendar.app has access to the same calendars
 - Verify the event was created in the correct calendar
+- Grant Full Calendar Access (see above)
 
 ### Fantastical not opening
 - Ensure Fantastical is installed

--- a/native/FantasticalHelper.swift
+++ b/native/FantasticalHelper.swift
@@ -1,0 +1,118 @@
+import EventKit
+import Foundation
+
+let store = EKEventStore()
+let sema = DispatchSemaphore(value: 0)
+let args = CommandLine.arguments
+let command = args.count > 1 ? args[1] : "today"
+let param = args.count > 2 ? args[2] : "7"
+
+func toISO(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    return formatter.string(from: date)
+}
+
+func formatDate(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter.string(from: date)
+}
+
+store.requestFullAccessToEvents { granted, error in
+    guard granted else {
+        let errorResult = ["error": "Calendar access denied. Grant Full Calendar Access in System Settings > Privacy & Security > Calendars."]
+        if let data = try? JSONSerialization.data(withJSONObject: errorResult),
+           let str = String(data: data, encoding: .utf8) {
+            print(str)
+        }
+        sema.signal()
+        return
+    }
+    
+    let cal = Calendar.current
+    
+    switch command {
+    case "today":
+        let start = cal.startOfDay(for: Date())
+        guard let end = cal.date(byAdding: .day, value: 1, to: start) else {
+            print("{\"error\": \"Date calculation failed\"}")
+            sema.signal()
+            return
+        }
+        let pred = store.predicateForEvents(withStart: start, end: end, calendars: nil)
+        let events = store.events(matching: pred).sorted { $0.startDate < $1.startDate }
+        
+        var result: [[String: String]] = []
+        for evt in events {
+            result.append([
+                "title": evt.title ?? "",
+                "calendar": evt.calendar.title,
+                "start": toISO(evt.startDate),
+                "end": toISO(evt.endDate),
+                "location": evt.location ?? ""
+            ])
+        }
+        
+        let output: [String: Any] = [
+            "date": formatDate(Date()),
+            "count": events.count,
+            "events": result
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: output),
+           let str = String(data: data, encoding: .utf8) {
+            print(str)
+        }
+        
+    case "upcoming":
+        let days = Int(param) ?? 7
+        let start = cal.startOfDay(for: Date())
+        guard let end = cal.date(byAdding: .day, value: days, to: start) else {
+            print("{\"error\": \"Date calculation failed\"}")
+            sema.signal()
+            return
+        }
+        let pred = store.predicateForEvents(withStart: start, end: end, calendars: nil)
+        let events = store.events(matching: pred).sorted { $0.startDate < $1.startDate }
+        
+        var result: [[String: String]] = []
+        for evt in events {
+            result.append([
+                "title": evt.title ?? "",
+                "calendar": evt.calendar.title,
+                "start": toISO(evt.startDate),
+                "end": toISO(evt.endDate),
+                "location": evt.location ?? ""
+            ])
+        }
+        
+        let output: [String: Any] = [
+            "range": [
+                "start": formatDate(start),
+                "end": formatDate(end),
+                "days": days
+            ],
+            "count": events.count,
+            "events": result
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: output),
+           let str = String(data: data, encoding: .utf8) {
+            print(str)
+        }
+        
+    case "calendars":
+        let cals = store.calendars(for: .event)
+        let result = cals.map { ["name": $0.title, "id": $0.calendarIdentifier] }
+        let output: [String: Any] = ["count": cals.count, "calendars": result]
+        if let data = try? JSONSerialization.data(withJSONObject: output),
+           let str = String(data: data, encoding: .utf8) {
+            print(str)
+        }
+        
+    default:
+        print("{\"error\": \"Unknown command. Use: today, upcoming [days], calendars\"}")
+    }
+    
+    sema.signal()
+}
+
+sema.wait()

--- a/native/build.sh
+++ b/native/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+DIST_DIR="$ROOT_DIR/dist/native"
+
+echo "Building FantasticalHelper.swift..."
+
+mkdir -p "$DIST_DIR"
+
+swiftc -O -o "$DIST_DIR/fantastical-helper" \
+    "$SCRIPT_DIR/FantasticalHelper.swift" \
+    -framework EventKit \
+    -framework Foundation
+
+echo "Built: $DIST_DIR/fantastical-helper"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-fantastical",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-fantastical",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0"
@@ -385,7 +385,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -590,7 +589,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1161,7 +1159,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-fantastical",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "mcpName": "io.github.jmchristian/mcp-fantastical",
   "description": "MCP server for Fantastical calendar app - create events, view calendar, and manage schedules",
   "main": "dist/index.js",
@@ -13,7 +13,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build:native": "./native/build.sh",
+    "build": "tsc && npm run build:native",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build"
   },
@@ -25,7 +26,8 @@
     "claude",
     "ai",
     "applescript",
-    "macos"
+    "macos",
+    "eventkit"
   ],
   "author": "Jim Christian",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,25 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { exec } from "child_process";
 import { promisify } from "util";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
 
 const execAsync = promisify(exec);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const NATIVE_HELPER_PATH = join(__dirname, "native", "fantastical-helper");
+
+async function runNativeHelper(command: string, arg?: string): Promise<string | null> {
+  try {
+    const cmd = arg ? `${NATIVE_HELPER_PATH} ${command} ${arg}` : `${NATIVE_HELPER_PATH} ${command}`;
+    const { stdout } = await execAsync(cmd, { timeout: 10000 });
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
 
 // Helper to run AppleScript
 async function runAppleScript(script: string): Promise<string> {
@@ -221,8 +238,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "fantastical_get_today": {
-        // Get events using Calendar app (Fantastical syncs with it)
-        // Use current date as reference to avoid locale parsing issues
+        // Try native EventKit helper first (faster, no AppleScript permission issues)
+        const nativeResult = await runNativeHelper("today");
+        if (nativeResult) {
+          return {
+            content: [{
+              type: "text",
+              text: nativeResult,
+            }],
+          };
+        }
+
+        // Fallback to AppleScript
         const script = `
 set output to ""
 set todayStart to current date
@@ -273,6 +300,18 @@ return output`;
       case "fantastical_get_upcoming": {
         const { days = 7 } = args as { days?: number };
 
+        // Try native EventKit helper first (faster, no AppleScript permission issues)
+        const nativeResult = await runNativeHelper("upcoming", String(days));
+        if (nativeResult) {
+          return {
+            content: [{
+              type: "text",
+              text: nativeResult,
+            }],
+          };
+        }
+
+        // Fallback to AppleScript
         const today = new Date();
         const endDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() + days);
 
@@ -346,6 +385,18 @@ return output`;
       }
 
       case "fantastical_get_calendars": {
+        // Try native EventKit helper first (faster, no AppleScript permission issues)
+        const nativeResult = await runNativeHelper("calendars");
+        if (nativeResult) {
+          return {
+            content: [{
+              type: "text",
+              text: nativeResult,
+            }],
+          };
+        }
+
+        // Fallback to AppleScript
         const script = `
 set output to ""
 tell application "Calendar"


### PR DESCRIPTION
## Problem

When `mcp-fantastical` runs as an MCP server spawned by a parent process (Claude Code, OpenCode, etc.), the AppleScript commands targeting Calendar.app fail with permission errors:
- Error `-1743`: "Not authorised to send Apple events to Calendar"
- Timeouts on large calendars (3000+ events) due to slow `whose` filter queries

This is reported in #2.

## Solution

Add a native Swift helper that uses EventKit framework for calendar queries. This bypasses AppleScript permission issues and is significantly faster.

### Changes
- **New**: `native/FantasticalHelper.swift` - Swift binary using EventKit
- **New**: `native/build.sh` - Build script for the helper
- **Changed**: `src/index.ts` - Try EventKit first, fallback to AppleScript
- **Changed**: `package.json` - Added `build:native` script
- **Updated**: `README.md` - Document Full Calendar Access requirement
- **Updated**: `CHANGELOG.md` - Document v1.1.0 changes

### Performance
- EventKit: <100ms for calendar queries
- AppleScript: 7-30+ seconds or timeout on large calendars

### Compatibility
- Falls back to AppleScript if EventKit helper is unavailable
- No breaking changes to tool interfaces

## Testing

Tested on macOS 26.3 (Tahoe) with:
- 9 calendars, 3700+ events
- MCP server spawned by OpenCode CLI
- Full Calendar Access permission granted

Closes #2