### PR TITLE
Add calendar CRUD via Swift EventKit helper

### DIFF
--- a/native/build.sh
+++ b/native/build.sh
@@ -1,17 +1,7 @@
 #!/bin/bash
 set -e
-
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(dirname "$SCRIPT_DIR")"
-DIST_DIR="$ROOT_DIR/dist/native"
-
-echo "Building FantasticalHelper.swift..."
-
-mkdir -p "$DIST_DIR"
-
-swiftc -O -o "$DIST_DIR/fantastical-helper" \
-    "$SCRIPT_DIR/FantasticalHelper.swift" \
-    -framework EventKit \
-    -framework Foundation
-
-echo "Built: $DIST_DIR/fantastical-helper"
+echo "Building fantastical-helper..."
+swiftc -O -o "$SCRIPT_DIR/../dist/native/fantastical-helper" "$SCRIPT_DIR/fantastical-helper.swift" \
+  -framework EventKit -framework CoreGraphics
+echo "Built: dist/native/fantastical-helper"

--- a/native/fantastical-helper.swift
+++ b/native/fantastical-helper.swift
@@ -1,0 +1,313 @@
+import EventKit
+import Foundation
+
+let store = EKEventStore()
+
+// Request calendar access synchronously
+func requestAccess() -> Bool {
+    let semaphore = DispatchSemaphore(value: 0)
+    var granted = false
+    store.requestFullAccessToEvents { g, error in
+        granted = g
+        if let error = error {
+            fputs("Error requesting access: \(error.localizedDescription)\n", stderr)
+        }
+        semaphore.signal()
+    }
+    semaphore.wait()
+    return granted
+}
+
+// Find calendars by name
+func findCalendars(named name: String) -> [EKCalendar] {
+    return store.calendars(for: .event).filter { $0.title == name }
+}
+
+// Find iCloud source
+func findICloudSource() -> EKSource? {
+    // Prefer iCloud
+    if let icloud = store.sources.first(where: { $0.sourceType == .calDAV && $0.title.lowercased().contains("icloud") }) {
+        return icloud
+    }
+    // Fallback to any CalDAV
+    if let caldav = store.sources.first(where: { $0.sourceType == .calDAV }) {
+        return caldav
+    }
+    // Fallback to local
+    return store.sources.first(where: { $0.sourceType == .local })
+}
+
+// JSON output helpers
+func jsonSuccess(_ dict: [String: Any]) {
+    if let data = try? JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted),
+       let str = String(data: data, encoding: .utf8) {
+        print(str)
+    }
+}
+
+func jsonError(_ msg: String) {
+    jsonSuccess(["success": false, "error": msg])
+    exit(1)
+}
+
+// MARK: - Commands
+
+func cmdCreateCalendar(name: String) {
+    let existing = findCalendars(named: name)
+    if !existing.isEmpty {
+        jsonSuccess(["success": true, "message": "Calendar '\(name)' already exists", "created": false, "count": existing.count])
+        return
+    }
+
+    guard let source = findICloudSource() else {
+        jsonError("No suitable calendar source found")
+        return
+    }
+
+    let calendar = EKCalendar(for: .event, eventStore: store)
+    calendar.title = name
+    calendar.source = source
+    calendar.cgColor = CGColor(red: 0.5, green: 0.2, blue: 0.9, alpha: 1.0)
+
+    do {
+        try store.saveCalendar(calendar, commit: true)
+        jsonSuccess(["success": true, "message": "Calendar '\(name)' created on \(source.title)", "created": true, "calendarId": calendar.calendarIdentifier])
+    } catch {
+        jsonError("Failed to create calendar: \(error.localizedDescription)")
+    }
+}
+
+func cmdDeleteCalendar(name: String, keepWithEvents: Bool) {
+    let calendars = findCalendars(named: name)
+    if calendars.isEmpty {
+        jsonSuccess(["success": true, "message": "No calendar named '\(name)' found", "deleted": 0])
+        return
+    }
+
+    var deleted = 0
+    for cal in calendars {
+        if keepWithEvents {
+            // Count events in next year
+            let start = Date()
+            let end = Calendar.current.date(byAdding: .year, value: 1, to: start)!
+            let predicate = store.predicateForEvents(withStart: start.addingTimeInterval(-365*24*3600), end: end, calendars: [cal])
+            let events = store.events(matching: predicate)
+            if !events.isEmpty {
+                continue // skip calendars with events
+            }
+        }
+        do {
+            try store.removeCalendar(cal, commit: true)
+            deleted += 1
+        } catch {
+            fputs("Warning: failed to delete calendar: \(error.localizedDescription)\n", stderr)
+        }
+    }
+    jsonSuccess(["success": true, "deleted": deleted, "total_found": calendars.count])
+}
+
+func cmdDeleteEvent(calendarName: String?, titleContains: String, dateStr: String?) {
+    var calendars: [EKCalendar]
+    if let name = calendarName {
+        calendars = findCalendars(named: name)
+        if calendars.isEmpty {
+            jsonError("No calendar named '\(name)' found")
+            return
+        }
+    } else {
+        calendars = store.calendars(for: .event)
+    }
+
+    // Date range: if date specified, use that day; otherwise search ±1 year
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+
+    var startDate: Date
+    var endDate: Date
+
+    if let ds = dateStr, let parsed = dateFormatter.date(from: ds) {
+        startDate = Calendar.current.startOfDay(for: parsed)
+        endDate = Calendar.current.date(byAdding: .day, value: 1, to: startDate)!
+    } else {
+        startDate = Date().addingTimeInterval(-365 * 24 * 3600)
+        endDate = Date().addingTimeInterval(365 * 24 * 3600)
+    }
+
+    let predicate = store.predicateForEvents(withStart: startDate, end: endDate, calendars: calendars)
+    let events = store.events(matching: predicate)
+
+    var deleted = 0
+    for event in events {
+        if event.title.contains(titleContains) {
+            do {
+                try store.remove(event, span: .thisEvent, commit: false)
+                deleted += 1
+            } catch {
+                fputs("Warning: failed to delete event '\(event.title ?? "")': \(error.localizedDescription)\n", stderr)
+            }
+        }
+    }
+
+    if deleted > 0 {
+        do {
+            try store.commit()
+        } catch {
+            jsonError("Failed to commit deletions: \(error.localizedDescription)")
+            return
+        }
+    }
+
+    jsonSuccess(["success": true, "deleted_count": deleted, "title_filter": titleContains, "calendar_filter": calendarName ?? "all", "date_filter": dateStr ?? "any"])
+}
+
+func cmdUpdateEvent(calendarName: String?, titleContains: String, newTitle: String?, newNotes: String?) {
+    var calendars: [EKCalendar]
+    if let name = calendarName {
+        calendars = findCalendars(named: name)
+        if calendars.isEmpty {
+            jsonError("No calendar named '\(name)' found")
+            return
+        }
+    } else {
+        calendars = store.calendars(for: .event)
+    }
+
+    // Search ±1 year
+    let startDate = Date().addingTimeInterval(-365 * 24 * 3600)
+    let endDate = Date().addingTimeInterval(365 * 24 * 3600)
+    let predicate = store.predicateForEvents(withStart: startDate, end: endDate, calendars: calendars)
+    let events = store.events(matching: predicate)
+
+    for event in events {
+        if event.title.contains(titleContains) {
+            if let t = newTitle { event.title = t }
+            if let n = newNotes { event.notes = n }
+
+            do {
+                try store.save(event, span: .thisEvent, commit: true)
+                jsonSuccess(["success": true, "updated_title": event.title ?? "", "calendar": event.calendar.title])
+                return
+            } catch {
+                jsonError("Failed to save event: \(error.localizedDescription)")
+                return
+            }
+        }
+    }
+
+    jsonSuccess(["success": false, "message": "No event found matching '\(titleContains)'"])
+}
+
+func cmdListEvents(calendarName: String, days: Int) {
+    let calendars = findCalendars(named: calendarName)
+    if calendars.isEmpty {
+        jsonError("No calendar named '\(calendarName)' found")
+        return
+    }
+
+    let startDate = Calendar.current.startOfDay(for: Date())
+    let endDate = Calendar.current.date(byAdding: .day, value: days, to: startDate)!
+    let predicate = store.predicateForEvents(withStart: startDate, end: endDate, calendars: calendars)
+    let events = store.events(matching: predicate).sorted { $0.startDate < $1.startDate }
+
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
+
+    var eventList: [[String: Any]] = []
+    for event in events {
+        eventList.append([
+            "title": event.title ?? "",
+            "start": dateFormatter.string(from: event.startDate),
+            "end": dateFormatter.string(from: event.endDate),
+            "notes": event.notes ?? "",
+            "calendar": event.calendar.title,
+        ])
+    }
+
+    jsonSuccess(["success": true, "count": eventList.count, "events": eventList])
+}
+
+// MARK: - Main
+
+guard requestAccess() else {
+    jsonError("Calendar access denied")
+    exit(1)
+}
+
+let args = CommandLine.arguments
+guard args.count >= 2 else {
+    fputs("Usage: fantastical-helper <command> [args...]\n", stderr)
+    fputs("Commands:\n", stderr)
+    fputs("  create-calendar <name>\n", stderr)
+    fputs("  delete-calendar <name> [--keep-with-events]\n", stderr)
+    fputs("  delete-event --title-contains <text> [--calendar <name>] [--date YYYY-MM-DD]\n", stderr)
+    fputs("  update-event --title-contains <text> [--calendar <name>] [--new-title <text>] [--new-notes <text>]\n", stderr)
+    fputs("  list-events --calendar <name> [--days N]\n", stderr)
+    exit(1)
+}
+
+let command = args[1]
+
+switch command {
+case "create-calendar":
+    guard args.count >= 3 else { jsonError("Missing calendar name"); exit(1) }
+    cmdCreateCalendar(name: args[2])
+
+case "delete-calendar":
+    guard args.count >= 3 else { jsonError("Missing calendar name"); exit(1) }
+    let keepWithEvents = args.contains("--keep-with-events")
+    cmdDeleteCalendar(name: args[2], keepWithEvents: keepWithEvents)
+
+case "delete-event":
+    var titleContains: String?
+    var calendarName: String?
+    var dateStr: String?
+    var i = 2
+    while i < args.count {
+        switch args[i] {
+        case "--title-contains": i += 1; if i < args.count { titleContains = args[i] }
+        case "--calendar": i += 1; if i < args.count { calendarName = args[i] }
+        case "--date": i += 1; if i < args.count { dateStr = args[i] }
+        default: break
+        }
+        i += 1
+    }
+    guard let title = titleContains else { jsonError("Missing --title-contains"); exit(1) }
+    cmdDeleteEvent(calendarName: calendarName, titleContains: title, dateStr: dateStr)
+
+case "update-event":
+    var titleContains: String?
+    var calendarName: String?
+    var newTitle: String?
+    var newNotes: String?
+    var i = 2
+    while i < args.count {
+        switch args[i] {
+        case "--title-contains": i += 1; if i < args.count { titleContains = args[i] }
+        case "--calendar": i += 1; if i < args.count { calendarName = args[i] }
+        case "--new-title": i += 1; if i < args.count { newTitle = args[i] }
+        case "--new-notes": i += 1; if i < args.count { newNotes = args[i] }
+        default: break
+        }
+        i += 1
+    }
+    guard let title = titleContains else { jsonError("Missing --title-contains"); exit(1) }
+    cmdUpdateEvent(calendarName: calendarName, titleContains: title, newTitle: newTitle, newNotes: newNotes)
+
+case "list-events":
+    var calendarName: String?
+    var days = 1
+    var i = 2
+    while i < args.count {
+        switch args[i] {
+        case "--calendar": i += 1; if i < args.count { calendarName = args[i] }
+        case "--days": i += 1; if i < args.count { days = Int(args[i]) ?? 1 }
+        default: break
+        }
+        i += 1
+    }
+    guard let name = calendarName else { jsonError("Missing --calendar"); exit(1) }
+    cmdListEvents(calendarName: name, days: days)
+
+default:
+    jsonError("Unknown command: \(command)")
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-fantastical",
-  "version": "1.1.0",
-  "mcpName": "io.github.aplaceforallmystuff/mcp-fantastical",
+  "version": "1.0.3",
+  "mcpName": "io.github.jmchristian/mcp-fantastical",
   "description": "MCP server for Fantastical calendar app - create events, view calendar, and manage schedules",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,13 +26,12 @@
     "claude",
     "ai",
     "applescript",
-    "macos",
-    "eventkit"
+    "macos"
   ],
   "author": "Jim Christian",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0"
+    "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,14 @@ async function runNativeHelper(command: string, arg?: string): Promise<string | 
   }
 }
 
+// Run native helper with full argument list (for CRUD operations)
+async function runNativeHelperArgs(args: string[]): Promise<string> {
+  const escapedArgs = args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(" ");
+  const cmd = `${NATIVE_HELPER_PATH} ${escapedArgs}`;
+  const { stdout } = await execAsync(cmd, { timeout: 15000 });
+  return stdout.trim();
+}
+
 // Helper to run AppleScript
 async function runAppleScript(script: string): Promise<string> {
   try {
@@ -170,6 +178,68 @@ const TOOLS: Tool[] = [
         },
       },
       required: ["query"],
+    },
+  },
+  {
+    name: "fantastical_create_calendar",
+    description: "Create a new calendar via EventKit. Creates on iCloud if available, otherwise locally. Idempotent — returns existing calendar if name already exists.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description: "Name for the new calendar (e.g., 'Projects', 'Automations')",
+        },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "fantastical_delete_event",
+    description: "Delete calendar events matching a title pattern via EventKit. Optionally filter by calendar and date.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        title_contains: {
+          type: "string",
+          description: "Text that the event title must contain (case-sensitive)",
+        },
+        calendar: {
+          type: "string",
+          description: "Optional: Only delete from this calendar",
+        },
+        date: {
+          type: "string",
+          description: "Optional: Only delete events on this date (YYYY-MM-DD)",
+        },
+      },
+      required: ["title_contains"],
+    },
+  },
+  {
+    name: "fantastical_update_event",
+    description: "Update properties of a calendar event matched by title via EventKit. Updates the first matching event.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        title_contains: {
+          type: "string",
+          description: "Text that the event title must contain (matches first found)",
+        },
+        calendar: {
+          type: "string",
+          description: "Optional: Only match events in this calendar",
+        },
+        new_title: {
+          type: "string",
+          description: "Optional: New title for the event",
+        },
+        new_notes: {
+          type: "string",
+          description: "Optional: New notes/description for the event",
+        },
+      },
+      required: ["title_contains"],
     },
   },
 ];
@@ -441,6 +511,48 @@ return output`;
             }, null, 2),
           }],
         };
+      }
+
+      case "fantastical_create_calendar": {
+        const { name: calName } = args as { name: string };
+        const result = await runNativeHelperArgs(["create-calendar", calName]);
+        return { content: [{ type: "text", text: result }] };
+      }
+
+      case "fantastical_delete_event": {
+        const { title_contains, calendar: calFilter, date } = args as {
+          title_contains: string;
+          calendar?: string;
+          date?: string;
+        };
+        const helperArgs = ["delete-event", "--title-contains", title_contains];
+        if (calFilter) { helperArgs.push("--calendar", calFilter); }
+        if (date) { helperArgs.push("--date", date); }
+        const result = await runNativeHelperArgs(helperArgs);
+        return { content: [{ type: "text", text: result }] };
+      }
+
+      case "fantastical_update_event": {
+        const { title_contains, calendar: calFilter, new_title, new_notes } = args as {
+          title_contains: string;
+          calendar?: string;
+          new_title?: string;
+          new_notes?: string;
+        };
+        if (!new_title && new_notes === undefined) {
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({ success: false, message: "No update properties provided (need new_title or new_notes)" }, null, 2),
+            }],
+          };
+        }
+        const helperArgs = ["update-event", "--title-contains", title_contains];
+        if (calFilter) { helperArgs.push("--calendar", calFilter); }
+        if (new_title) { helperArgs.push("--new-title", new_title); }
+        if (new_notes !== undefined) { helperArgs.push("--new-notes", new_notes || ""); }
+        const result = await runNativeHelperArgs(helperArgs);
+        return { content: [{ type: "text", text: result }] };
       }
 
       default:


### PR DESCRIPTION
Adds three new MCP tools for calendar mutation operations, backed by a Swift EventKit binary:

* \`fantastical_create_calendar\` — create calendars on iCloud (idempotent, returns existing if name matches)
* \`fantastical_delete_event\` — delete events by title match, optional calendar and date filters
* \`fantastical_update_event\` — update event title or notes (matches first event found)

**Why EventKit instead of AppleScript?**

Calendar.app's AppleScript dictionary has limitations for mutation operations:
* \`uid\`/\`id\` properties aren't reliably accessible (errors on some macOS versions)
* Events created by Fantastical sometimes aren't visible to Calendar.app's AppleScript context (cross-store visibility)
* \`set description of evt\` (notes) doesn't work reliably via AppleScript

The Swift EventKit binary (\`native/fantastical-helper.swift\`) avoids all of these by using the EventKit framework directly. It supports:
* \`create-calendar <name>\` — creates on iCloud CalDAV source
* \`delete-event --title-contains <text> [--calendar <name>] [--date YYYY-MM-DD]\`
* \`update-event --title-contains <text> [--calendar <name>] [--new-title <text>] [--new-notes <text>]\`
* \`list-events --calendar <name> [--days N]\`
* \`delete-calendar <name> [--keep-with-events]\`

All output is JSON. The binary is compiled by \`native/build.sh\` as part of \`npm run build\`. Requires macOS with Swift toolchain (ships with Xcode CLI tools).

This builds on the existing native helper pattern from PR #5 — same architecture (compiled binary in \`dist/native/\`), just with write operations added.