### PR TITLE
Add find/update/delete event tools via EventKit

### DIFF
--- a/native/FantasticalHelper.swift
+++ b/native/FantasticalHelper.swift
@@ -1,14 +1,24 @@
 import EventKit
 import Foundation
 
-// Args: <command> [<param>] [--output <path>]
-//   command: today | upcoming | calendars
+// Args: <command> [<param>] [--flag value ...] [--output <path>]
+//   command: today | upcoming | calendars | find | update | delete
 //   param:   for 'upcoming', the number of days (default 7)
+//
+//   find:    --query <text>   (substring match on title, case-insensitive)
+//            --days <n>        (search window ±n days, default 30)
+//            --calendar <name> (optional, restrict to one calendar)
+//   update:  --id <eventIdentifier>  plus any of:
+//            --title <text> --start <ISO8601> --end <ISO8601>
+//            --location <text> --notes <text> --calendar <name>
+//   delete:  --id <eventIdentifier>  [--span thisEvent|futureEvents]
+//
 //   --output <path>: if given, JSON is written to this file instead of stdout.
 //                    Required when launched via `open -W` because `open` detaches stdio.
 
 let allArgs = CommandLine.arguments
 var positional: [String] = []
+var flags: [String: String] = [:]
 var outputPath: String? = nil
 
 var i = 1
@@ -16,6 +26,9 @@ while i < allArgs.count {
     let a = allArgs[i]
     if a == "--output", i + 1 < allArgs.count {
         outputPath = allArgs[i + 1]
+        i += 2
+    } else if a.hasPrefix("--"), i + 1 < allArgs.count {
+        flags[String(a.dropFirst(2))] = allArgs[i + 1]
         i += 2
     } else {
         positional.append(a)
@@ -50,10 +63,32 @@ func toISO(_ date: Date) -> String {
     ISO8601DateFormatter().string(from: date)
 }
 
+func parseISO(_ s: String) -> Date? {
+    // Accept ISO8601 both with and without fractional seconds.
+    let f1 = ISO8601DateFormatter()
+    if let d = f1.date(from: s) { return d }
+    let f2 = ISO8601DateFormatter()
+    f2.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return f2.date(from: s)
+}
+
 func formatDate(_ date: Date) -> String {
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM-dd"
     return formatter.string(from: date)
+}
+
+// Serialize an event including its stable identifier so callers can update/delete it.
+func eventDict(_ evt: EKEvent) -> [String: String] {
+    [
+        "id": evt.eventIdentifier ?? "",
+        "title": evt.title ?? "",
+        "calendar": evt.calendar.title,
+        "start": toISO(evt.startDate),
+        "end": toISO(evt.endDate),
+        "location": evt.location ?? "",
+        "notes": evt.notes ?? ""
+    ]
 }
 
 store.requestFullAccessToEvents { granted, _ in
@@ -75,19 +110,10 @@ store.requestFullAccessToEvents { granted, _ in
         }
         let pred = store.predicateForEvents(withStart: start, end: end, calendars: nil)
         let events = store.events(matching: pred).sorted { $0.startDate < $1.startDate }
-        let result: [[String: String]] = events.map { evt in
-            [
-                "title": evt.title ?? "",
-                "calendar": evt.calendar.title,
-                "start": toISO(evt.startDate),
-                "end": toISO(evt.endDate),
-                "location": evt.location ?? ""
-            ]
-        }
         emit([
             "date": formatDate(Date()),
             "count": events.count,
-            "events": result
+            "events": events.map(eventDict)
         ] as [String: Any])
 
     case "upcoming":
@@ -100,15 +126,6 @@ store.requestFullAccessToEvents { granted, _ in
         }
         let pred = store.predicateForEvents(withStart: start, end: end, calendars: nil)
         let events = store.events(matching: pred).sorted { $0.startDate < $1.startDate }
-        let result: [[String: String]] = events.map { evt in
-            [
-                "title": evt.title ?? "",
-                "calendar": evt.calendar.title,
-                "start": toISO(evt.startDate),
-                "end": toISO(evt.endDate),
-                "location": evt.location ?? ""
-            ]
-        }
         emit([
             "range": [
                 "start": formatDate(start),
@@ -116,7 +133,7 @@ store.requestFullAccessToEvents { granted, _ in
                 "days": days
             ],
             "count": events.count,
-            "events": result
+            "events": events.map(eventDict)
         ] as [String: Any])
 
     case "calendars":
@@ -124,8 +141,110 @@ store.requestFullAccessToEvents { granted, _ in
         let result = cals.map { ["name": $0.title, "id": $0.calendarIdentifier] }
         emit(["count": cals.count, "calendars": result] as [String: Any])
 
+    case "find":
+        // Substring search over a window (default ±30 days) so callers can locate
+        // an event's identifier before updating/deleting it.
+        guard let query = flags["query"], !query.isEmpty else {
+            emit("{\"error\":\"find requires --query <text>\"}")
+            sema.signal()
+            return
+        }
+        let days = Int(flags["days"] ?? "30") ?? 30
+        let now = Date()
+        guard let start = cal.date(byAdding: .day, value: -days, to: now),
+              let end = cal.date(byAdding: .day, value: days, to: now) else {
+            emit("{\"error\":\"Date calculation failed\"}")
+            sema.signal()
+            return
+        }
+        var calendars: [EKCalendar]? = nil
+        if let calName = flags["calendar"] {
+            calendars = store.calendars(for: .event).filter { $0.title == calName }
+        }
+        let pred = store.predicateForEvents(withStart: start, end: end, calendars: calendars)
+        let q = query.lowercased()
+        let events = store.events(matching: pred)
+            .filter { ($0.title ?? "").lowercased().contains(q) }
+            .sorted { $0.startDate < $1.startDate }
+        emit([
+            "query": query,
+            "count": events.count,
+            "events": events.map(eventDict)
+        ] as [String: Any])
+
+    case "update":
+        guard let id = flags["id"], !id.isEmpty else {
+            emit("{\"error\":\"update requires --id <eventIdentifier>\"}")
+            sema.signal()
+            return
+        }
+        guard let evt = store.event(withIdentifier: id) else {
+            emit(["error": "No event found with id \(id)"])
+            sema.signal()
+            return
+        }
+        if let t = flags["title"] { evt.title = t }
+        if let s = flags["start"] {
+            guard let d = parseISO(s) else {
+                emit(["error": "Invalid --start; expected ISO8601 like 2026-06-02T15:00:00Z"])
+                sema.signal()
+                return
+            }
+            evt.startDate = d
+        }
+        if let e = flags["end"] {
+            guard let d = parseISO(e) else {
+                emit(["error": "Invalid --end; expected ISO8601 like 2026-06-02T16:00:00Z"])
+                sema.signal()
+                return
+            }
+            evt.endDate = d
+        }
+        if let loc = flags["location"] { evt.location = loc }
+        if let n = flags["notes"] { evt.notes = n }
+        if let calName = flags["calendar"] {
+            if let target = store.calendars(for: .event).first(where: { $0.title == calName }) {
+                evt.calendar = target
+            } else {
+                emit(["error": "No calendar named '\(calName)'"])
+                sema.signal()
+                return
+            }
+        }
+        if evt.endDate <= evt.startDate {
+            emit(["error": "Event end must be after start"])
+            sema.signal()
+            return
+        }
+        do {
+            try store.save(evt, span: .thisEvent, commit: true)
+            emit(["success": true, "action": "updated", "event": eventDict(evt)] as [String: Any])
+        } catch {
+            emit(["error": "Failed to update: \(error.localizedDescription)"])
+        }
+
+    case "delete":
+        guard let id = flags["id"], !id.isEmpty else {
+            emit("{\"error\":\"delete requires --id <eventIdentifier>\"}")
+            sema.signal()
+            return
+        }
+        guard let evt = store.event(withIdentifier: id) else {
+            emit(["error": "No event found with id \(id)"])
+            sema.signal()
+            return
+        }
+        let span: EKSpan = (flags["span"] == "futureEvents") ? .futureEvents : .thisEvent
+        let summary = eventDict(evt)
+        do {
+            try store.remove(evt, span: span, commit: true)
+            emit(["success": true, "action": "deleted", "event": summary] as [String: Any])
+        } catch {
+            emit(["error": "Failed to delete: \(error.localizedDescription)"])
+        }
+
     default:
-        emit("{\"error\":\"Unknown command. Use: today, upcoming [days], calendars\"}")
+        emit("{\"error\":\"Unknown command. Use: today, upcoming [days], calendars, find, update, delete\"}")
     }
 
     sema.signal()

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,11 @@ function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }
 
-async function runNativeHelper(command: string, arg?: string): Promise<string | null> {
+async function runNativeHelper(
+  command: string,
+  arg?: string,
+  flags?: Record<string, string | undefined>,
+): Promise<string | null> {
   // Create a per-invocation temp directory for the JSON output, so concurrent
   // calls can't collide and we always clean up.
   const workDir = mkdtempSync(join(tmpdir(), "mcp-fantastical-"));
@@ -50,6 +54,13 @@ async function runNativeHelper(command: string, arg?: string): Promise<string | 
   try {
     const helperArgs = [command];
     if (arg) helperArgs.push(arg);
+    if (flags) {
+      for (const [key, value] of Object.entries(flags)) {
+        if (value !== undefined && value !== null && value !== "") {
+          helperArgs.push(`--${key}`, String(value));
+        }
+      }
+    }
     helperArgs.push("--output", outputPath);
 
     const quotedArgs = helperArgs.map(shellQuote).join(" ");
@@ -204,6 +215,67 @@ const TOOLS: Tool[] = [
         },
       },
       required: ["query"],
+    },
+  },
+  {
+    name: "fantastical_find_events",
+    description: "Find events whose title matches a query and return their identifiers, so they can be updated or deleted. Searches a ±N day window via EventKit. Returns each event's stable 'id' for use with fantastical_update_event / fantastical_delete_event.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        query: {
+          type: "string",
+          description: "Case-insensitive substring to match against event titles",
+        },
+        days: {
+          type: "number",
+          description: "Search window in days, both past and future (default: 30)",
+        },
+        calendar: {
+          type: "string",
+          description: "Optional: restrict the search to a single calendar by name",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "fantastical_update_event",
+    description: "Update an existing calendar event (reschedule, rename, move calendars, change location/notes). Requires the event 'id' from fantastical_find_events. Only the fields you provide are changed.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: {
+          type: "string",
+          description: "The event identifier (from fantastical_find_events)",
+        },
+        title: { type: "string", description: "New title" },
+        start: { type: "string", description: "New start time, ISO 8601 (e.g. 2026-06-02T15:00:00Z)" },
+        end: { type: "string", description: "New end time, ISO 8601 (e.g. 2026-06-02T16:00:00Z)" },
+        location: { type: "string", description: "New location" },
+        notes: { type: "string", description: "New notes" },
+        calendar: { type: "string", description: "Move the event to this calendar (by name)" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "fantastical_delete_event",
+    description: "Delete a calendar event. Requires the event 'id' from fantastical_find_events. For recurring events, span 'thisEvent' deletes only this occurrence (default); 'futureEvents' deletes this and all future occurrences.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: {
+          type: "string",
+          description: "The event identifier (from fantastical_find_events)",
+        },
+        span: {
+          type: "string",
+          enum: ["thisEvent", "futureEvents"],
+          description: "For recurring events: delete only this occurrence or this and all future (default: thisEvent)",
+        },
+      },
+      required: ["id"],
     },
   },
 ];
@@ -475,6 +547,86 @@ return output`;
             }, null, 2),
           }],
         };
+      }
+
+      case "fantastical_find_events": {
+        const { query, days, calendar } = args as {
+          query: string;
+          days?: number;
+          calendar?: string;
+        };
+
+        const result = await runNativeHelper("find", undefined, {
+          query,
+          days: days !== undefined ? String(days) : undefined,
+          calendar,
+        });
+
+        if (!result) {
+          throw new Error(
+            "Native EventKit helper failed. Finding events requires the FantasticalHelper " +
+            "with Calendar access (System Settings > Privacy & Security > Calendars).",
+          );
+        }
+
+        return { content: [{ type: "text", text: result }] };
+      }
+
+      case "fantastical_update_event": {
+        const { id, title, start, end, location, notes, calendar } = args as {
+          id: string;
+          title?: string;
+          start?: string;
+          end?: string;
+          location?: string;
+          notes?: string;
+          calendar?: string;
+        };
+
+        const result = await runNativeHelper("update", undefined, {
+          id, title, start, end, location, notes, calendar,
+        });
+
+        if (!result) {
+          throw new Error(
+            "Native EventKit helper failed. Updating events requires the FantasticalHelper " +
+            "with Calendar access (System Settings > Privacy & Security > Calendars).",
+          );
+        }
+
+        // Surface helper-level errors (bad id, invalid date, etc.) as tool errors.
+        const parsed = JSON.parse(result);
+        if (parsed.error) {
+          return {
+            content: [{ type: "text", text: `Error: ${parsed.error}` }],
+            isError: true,
+          };
+        }
+
+        return { content: [{ type: "text", text: result }] };
+      }
+
+      case "fantastical_delete_event": {
+        const { id, span } = args as { id: string; span?: string };
+
+        const result = await runNativeHelper("delete", undefined, { id, span });
+
+        if (!result) {
+          throw new Error(
+            "Native EventKit helper failed. Deleting events requires the FantasticalHelper " +
+            "with Calendar access (System Settings > Privacy & Security > Calendars).",
+          );
+        }
+
+        const parsed = JSON.parse(result);
+        if (parsed.error) {
+          return {
+            content: [{ type: "text", text: `Error: ${parsed.error}` }],
+            isError: true,
+          };
+        }
+
+        return { content: [{ type: "text", text: result }] };
       }
 
       default:


### PR DESCRIPTION
## Summary

Adds three MCP tools so events can be **modified**, not just read/created:

- **`fantastical_find_events`** — case-insensitive title substring search over a ±N day window, returning each event's stable EventKit `id`.
- **`fantastical_update_event`** — reschedule / rename / move calendars / change location/notes by `id`. Only the fields you pass are changed.
- **`fantastical_delete_event`** — delete by `id`, with `thisEvent` / `futureEvents` span for recurring events.

## Why

The `x-fantastical3://` URL scheme can create events but can't modify or delete existing ones, and the existing read tools never exposed event identifiers. These three tools close the CRUD gap by going through the existing `FantasticalHelper` (EventKit).

## Changes

- **`native/FantasticalHelper.swift`**: new `find` / `update` / `delete` commands; a flexible `--flag value` parser alongside the existing positional args; existing `today`/`upcoming`/`calendars` reads now include the event `id` (and `notes`). Update validates ISO‑8601 dates, unknown calendar names, and `end > start`.
- **`src/index.ts`**: three new tool definitions + handlers; `runNativeHelper` now accepts arbitrary `--flags`. Mutating ops have no URL‑scheme fallback and surface helper errors (bad id, invalid date, unknown calendar, end ≤ start) as tool errors.

## Testing

- `npm run build` (tsc + Swift) succeeds; `tsc --noEmit` is clean.
- Read path unchanged (still EventKit‑first with AppleScript fallback).
- Mutating ops require the one‑time Calendar (TCC) grant for `FantasticalHelper`, same as the existing read commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)